### PR TITLE
fix: 잡코리아/사람인 크롤링 실패 시 빈 템플릿 반환하도록 수정하고 병합 로직 개선

### DIFF
--- a/crawl/jobkorea.py
+++ b/crawl/jobkorea.py
@@ -230,7 +230,12 @@ def parse_company_info(driver) -> dict:
         "trademark_count": "", # 상표 수
         "ip_details": "", # 지식재산 상세 정보
         "tech_stack": "", # 기술 스택 키워드
-        "recent_news": "" # 최근 뉴스/보도자료
+        "recent_news": "", # 최근 뉴스/보도자료
+        "target_customers": "", # 주요 목표 고객층
+        "competitors": "", # 주요 경쟁사
+        "strengths": "", # 강점
+        "risk_factors": "", # 위험 요인
+        "recent_trends": "" # 최근 동향
     }
     
     return company_data
@@ -239,37 +244,42 @@ USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 
 # 검색 실패 시 리턴할 기본 템플릿
 basic_template = {
-    "name": "",
-    "established_year": "",
-    "company_type": "",
-    "is_listed": False,
-    "homepage": "",
-    "description": "",
-    "address": "",
-    "industry": "",
-    "products_services": "",
-    "key_executive": "",
-    "employee_count": "",
-    "employee_history": "",
-    "latest_revenue": "",
-    "latest_operating_income": "",
-    "latest_net_income": "",
-    "latest_fiscal_year": "",
-    "financial_history": {},
-    "total_funding": "",
-    "latest_funding_round": "",
-    "latest_funding_date": "",
-    "latest_valuation": "",
-    "investment_history": "",
-    "investors": "",
-    "market_cap": "",
-    "stock_ticker": "",
-    "stock_exchange": "",
-    "patent_count": "",
-    "trademark_count": "",
-    "ip_details": "",
-    "tech_stack": "",
-    "recent_news": ""
+    "name": "", # 회사명
+    "established_year": "", # 설립 연도
+    "company_type": "", # 회사 유형 (주식회사, 유한회사 등)
+    "is_listed": False, # 상장 여부
+    "homepage": "", # 회사 홈페이지 URL
+    "description": "", # 회사 설명
+    "address": "", # 회사 주소
+    "industry": "", # 산업 분야 정보
+    "products_services": "", # 제품/서비스 이름 배열
+    "key_executive": "", # 주요 경영진(대표자) 이름
+    "employee_count": "", # 현재 직원 수
+    "employee_history": "", # 과거 직원 수 추이
+    "latest_revenue": "", # 최근 매출액 (원)
+    "latest_operating_income": "", # 최근 영업이익 (원)
+    "latest_net_income": "", # 최근 순이익 (원)
+    "latest_fiscal_year": "", # 최근 재무 정보의 회계연도
+    "financial_history": {}, # 과거 재무 정보 히스토리
+    "total_funding": "", # 총 투자 유치 금액 (원)
+    "latest_funding_round": "", # 최근 투자 라운드 명칭
+    "latest_funding_date": "", # 최근 투자 날짜
+    "latest_valuation": "", # 최근 기업가치 (원)
+    "investment_history": "", # 투자 히스토리
+    "investors": "", # 주요 투자자 목록
+    "market_cap": "", # 시가총액 (원)
+    "stock_ticker": "", # 주식 종목 코드
+    "stock_exchange": "", # 상장된 증권거래소
+    "patent_count": "", # 특허 수
+    "trademark_count": "", # 상표 수
+    "ip_details": "", # 지식재산 상세 정보
+    "tech_stack": "", # 기술 스택 키워드
+    "recent_news": "", # 최근 뉴스/보도자료
+    "target_customers": "", # 주요 목표 고객층
+    "competitors": "", # 주요 경쟁사
+    "strengths": "", # 강점
+    "risk_factors": "", # 위험 요인  
+    "recent_trends": "", # 최근 동향
 }
 
 def smart_crawl_jobkorea(company_name: str) -> dict:

--- a/crawl/jobkorea.py
+++ b/crawl/jobkorea.py
@@ -1,11 +1,10 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from bs4 import BeautifulSoup
-from datetime import datetime
+from copy import deepcopy
 import json, time
 
 # 공통 유틸 함수
@@ -236,8 +235,42 @@ def parse_company_info(driver) -> dict:
     
     return company_data
 
-# CHROME_DRIVER_PATH = "C:\\Users\\okoko\\Downloads\\chromedriver-win64\\chromedriver.exe" # 본인 경로로 수정 필요!
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+# 검색 실패 시 리턴할 기본 템플릿
+basic_template = {
+    "name": "",
+    "established_year": "",
+    "company_type": "",
+    "is_listed": False,
+    "homepage": "",
+    "description": "",
+    "address": "",
+    "industry": "",
+    "products_services": "",
+    "key_executive": "",
+    "employee_count": "",
+    "employee_history": "",
+    "latest_revenue": "",
+    "latest_operating_income": "",
+    "latest_net_income": "",
+    "latest_fiscal_year": "",
+    "financial_history": {},
+    "total_funding": "",
+    "latest_funding_round": "",
+    "latest_funding_date": "",
+    "latest_valuation": "",
+    "investment_history": "",
+    "investors": "",
+    "market_cap": "",
+    "stock_ticker": "",
+    "stock_exchange": "",
+    "patent_count": "",
+    "trademark_count": "",
+    "ip_details": "",
+    "tech_stack": "",
+    "recent_news": ""
+}
 
 def smart_crawl_jobkorea(company_name: str) -> dict:
     print(f"=== '{company_name}' 기업 정보 수집 시작 ===")
@@ -249,6 +282,7 @@ def smart_crawl_jobkorea(company_name: str) -> dict:
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("--headless=new")
     chrome_options.add_argument("--enable-unsafe-swiftshader")
+    chrome_options.add_argument("--log-level=3")
     chrome_options.add_argument(f"user-agent={USER_AGENT}")
 
     driver = webdriver.Chrome(options=chrome_options)
@@ -311,7 +345,8 @@ def smart_crawl_jobkorea(company_name: str) -> dict:
                     break
 
         if not info_url:
-            raise Exception(f"'{company_name}'과 일치하는 기업을 찾을 수 없습니다.")
+            print(f"'{company_name}'과 일치하는 기업을 찾을 수 없습니다.")
+            return deepcopy(basic_template)
 
         print("▶ 기업정보 링크:", info_url)
         driver.get(info_url)
@@ -319,15 +354,8 @@ def smart_crawl_jobkorea(company_name: str) -> dict:
         return parse_company_info(driver)
 
     except Exception as e:
-        return {"error": f"기업 정보 수집 실패: {str(e)}"}
+        print(f"[예외 발생] smart_crawl_jobkorea: {e}")
+        return deepcopy(basic_template)
 
     finally:
         driver.quit()
-
-# 실행
-if __name__ == "__main__":
-    company_name = input("회사명을 입력하세요: ")
-    result = smart_crawl_jobkorea(company_name)
-
-    print("\n[기업정보 수집 결과]")
-    print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/integration/integration_company_info.py
+++ b/integration/integration_company_info.py
@@ -12,37 +12,42 @@ def merge_company_info (jobkorea_data: dict, saramin_data: dict) -> dict :
     
     # 기본 통합 데이터 템플릿
     basic_template = {
-        "name": "",
-        "established_year": "",
-        "company_type": "",
-        "is_listed": False,
-        "homepage": "",
-        "description": "",
-        "address": "",
-        "industry": "",
-        "products_services": "",
-        "key_executive": "",
-        "employee_count": "",
-        "employee_history": "",
-        "latest_revenue": "",
-        "latest_operating_income": "",
-        "latest_net_income": "",
-        "latest_fiscal_year": "",
-        "financial_history": {},
-        "total_funding": "",
-        "latest_funding_round": "",
-        "latest_funding_date": "",
-        "latest_valuation": "",
-        "investment_history": "",
-        "investors": "",
-        "market_cap": "",
-        "stock_ticker": "",
-        "stock_exchange": "",
-        "patent_count": "",
-        "trademark_count": "",
-        "ip_details": "",
-        "tech_stack": "",
-        "recent_news": ""
+        "name": "", # 회사명
+        "established_year": "", # 설립 연도
+        "company_type": "", # 회사 유형 (주식회사, 유한회사 등)
+        "is_listed": False, # 상장 여부
+        "homepage": "", # 회사 홈페이지 URL
+        "description": "", # 회사 설명
+        "address": "", # 회사 주소
+        "industry": "", # 산업 분야 정보
+        "products_services": "", # 제품/서비스 이름 배열
+        "key_executive": "", # 주요 경영진(대표자) 이름
+        "employee_count": "", # 현재 직원 수
+        "employee_history": "", # 과거 직원 수 추이
+        "latest_revenue": "", # 최근 매출액 (원)
+        "latest_operating_income": "", # 최근 영업이익 (원)
+        "latest_net_income": "", # 최근 순이익 (원)
+        "latest_fiscal_year": "", # 최근 재무 정보의 회계연도
+        "financial_history": {}, # 과거 재무 정보 히스토리
+        "total_funding": "", # 총 투자 유치 금액 (원)
+        "latest_funding_round": "", # 최근 투자 라운드 명칭
+        "latest_funding_date": "", # 최근 투자 날짜
+        "latest_valuation": "", # 최근 기업가치 (원)
+        "investment_history": "", # 투자 히스토리
+        "investors": "", # 주요 투자자 목록
+        "market_cap": "", # 시가총액 (원)
+        "stock_ticker": "", # 주식 종목 코드
+        "stock_exchange": "", # 상장된 증권거래소
+        "patent_count": "", # 특허 수
+        "trademark_count": "", # 상표 수
+        "ip_details": "", # 지식재산 상세 정보
+        "tech_stack": "", # 기술 스택 키워드
+        "recent_news": "", # 최근 뉴스/보도자료
+        "target_customers": "", # 주요 목표 고객층
+        "competitors": "", # 주요 경쟁사
+        "strengths": "", # 강점
+        "risk_factors": "", # 위험 요인  
+        "recent_trends": "", # 최근 동향
     }
 
     # 데이터 수집이 실패된 경우

--- a/integration/integration_company_info.py
+++ b/integration/integration_company_info.py
@@ -1,19 +1,67 @@
+from copy import deepcopy
+
 """
 잡코리아 기준으로 사람인 데이터 통합
 - 잡코리아 데이터가 비어 있는 경우("", None, {}, [], "null") → 사람인 데이터로 보완
 - is_listed 필드는 두 값 중 하나라도 True면 True로 설정
 """
 def merge_company_info (jobkorea_data: dict, saramin_data: dict) -> dict :
- 
-    merged_data = {} # 최종 통합 데이터
 
     def is_empty(value):
         return value in ["", None, {}, [], "null"]
     
+    # 기본 통합 데이터 템플릿
+    basic_template = {
+        "name": "",
+        "established_year": "",
+        "company_type": "",
+        "is_listed": False,
+        "homepage": "",
+        "description": "",
+        "address": "",
+        "industry": "",
+        "products_services": "",
+        "key_executive": "",
+        "employee_count": "",
+        "employee_history": "",
+        "latest_revenue": "",
+        "latest_operating_income": "",
+        "latest_net_income": "",
+        "latest_fiscal_year": "",
+        "financial_history": {},
+        "total_funding": "",
+        "latest_funding_round": "",
+        "latest_funding_date": "",
+        "latest_valuation": "",
+        "investment_history": "",
+        "investors": "",
+        "market_cap": "",
+        "stock_ticker": "",
+        "stock_exchange": "",
+        "patent_count": "",
+        "trademark_count": "",
+        "ip_details": "",
+        "tech_stack": "",
+        "recent_news": ""
+    }
+
+    # 데이터 수집이 실패된 경우
+    if not isinstance(jobkorea_data, dict) or "error" in jobkorea_data:
+        jobkorea_data = {}
+    if not isinstance(saramin_data, dict) or "error" in saramin_data:
+        saramin_data = {}
+
+    # 모든 사이트가 실패한 경우
+    if not jobkorea_data and not saramin_data:
+        return deepcopy(basic_template)
+    
+    # 최종 통합 데이터
+    merged_data = {}
+    
     # 잡코리아 JSON 키 순서대로 탐색
-    for key in jobkorea_data:
-        jobkorea_value = jobkorea_data[key]
-        saramin_value = saramin_data.get(key, "")
+    for key in basic_template:
+        jobkorea_value = jobkorea_data.get(key)
+        saramin_value = saramin_data.get(key)
 
         if key == "is_listed":
             merged_data[key] = bool(jobkorea_value) or bool(saramin_value)
@@ -23,23 +71,26 @@ def merge_company_info (jobkorea_data: dict, saramin_data: dict) -> dict :
             merged_data[key] = {}
 
             # 잡코리아 기준 먼저 복사
-            for year, jobkorea_year_data in jobkorea_value.items():
-                merged_data[key][year] = jobkorea_year_data.copy()
+            if isinstance(jobkorea_value, dict):
+                for year, jobkorea_year_data in jobkorea_value.items():
+                    merged_data[key][year] = jobkorea_year_data.copy()
 
             # 사람인 연도별 병합
-            for year, saramin_year_data in saramin_value.items():
-                if year not in merged_data[key]:
-                    merged_data[key][year] = saramin_year_data
-                else:
-                    for metric, value in saramin_year_data.items():
-                        if metric not in merged_data[key][year] or is_empty(merged_data[key][year][metric]):
-                            merged_data[key][year][metric] = value
+            if isinstance(saramin_value, dict):
+                for year, saramin_year_data in saramin_value.items():
+                    if year not in merged_data[key]:
+                        merged_data[key][year] = saramin_year_data
+                    else:
+                        for metric, value in saramin_year_data.items():
+                            if metric not in merged_data[key][year] or is_empty(merged_data[key][year][metric]):
+                                merged_data[key][year][metric] = value
 
         # 일반 필드 처리
         elif is_empty(jobkorea_value) and not is_empty(saramin_value):
             merged_data[key] = saramin_value
-
-        else:
+        elif not is_empty(jobkorea_value):
             merged_data[key] = jobkorea_value
+        else:
+            merged_data[key] = deepcopy(basic_template[key])
 
     return merged_data


### PR DESCRIPTION
[ 추가 작업 ]
- 기업 정보에 target_customers, competitors 등 필드 추가
- 추가된 필드
"target_customers": "", # 주요 목표 고객층
"competitors": "", # 주요 경쟁사
"strengths": "", # 강점
"risk_factors": "", # 위험 요인  
"recent_trends": "" # 최근 동향