### PR TITLE
refactor: 기업 정보 템플릿 공통 파일로 분리 및 적용

### DIFF
--- a/common/common_field_template.py
+++ b/common/common_field_template.py
@@ -1,0 +1,38 @@
+basic_template = {
+    "name": "", # 회사명
+    "established_year": "", # 설립 연도
+    "company_type": "", # 회사 유형 (주식회사, 유한회사 등)
+    "is_listed": False, # 상장 여부
+    "homepage": "", # 회사 홈페이지 URL
+    "description": "", # 회사 설명
+    "address": "", # 회사 주소
+    "industry": "", # 산업 분야 정보
+    "products_services": "", # 제품/서비스 이름 배열
+    "key_executive": "", # 주요 경영진(대표자) 이름
+    "employee_count": "", # 현재 직원 수
+    "employee_history": "", # 과거 직원 수 추이
+    "latest_revenue": "", # 최근 매출액 (원)
+    "latest_operating_income": "", # 최근 영업이익 (원)
+    "latest_net_income": "", # 최근 순이익 (원)
+    "latest_fiscal_year": "", # 최근 재무 정보의 회계연도
+    "financial_history": {}, # 과거 재무 정보 히스토리
+    "total_funding": "", # 총 투자 유치 금액 (원)
+    "latest_funding_round": "", # 최근 투자 라운드 명칭
+    "latest_funding_date": "", # 최근 투자 날짜
+    "latest_valuation": "", # 최근 기업가치 (원)
+    "investment_history": "", # 투자 히스토리
+    "investors": "", # 주요 투자자 목록
+    "market_cap": "", # 시가총액 (원)
+    "stock_ticker": "", # 주식 종목 코드
+    "stock_exchange": "", # 상장된 증권거래소
+    "patent_count": "", # 특허 수
+    "trademark_count": "", # 상표 수
+    "ip_details": "", # 지식재산 상세 정보
+    "tech_stack": "", # 기술 스택 키워드
+    "recent_news": "", # 최근 뉴스/보도자료
+    "target_customers": "", # 주요 목표 고객층
+    "competitors": "", # 주요 경쟁사
+    "strengths": "", # 강점
+    "risk_factors": "", # 위험 요인  
+    "recent_trends": "", # 최근 동향
+}

--- a/integration/integration_company_info.py
+++ b/integration/integration_company_info.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from common.common_field_template import basic_template
 
 """
 잡코리아 기준으로 사람인 데이터 통합
@@ -9,46 +10,6 @@ def merge_company_info (jobkorea_data: dict, saramin_data: dict) -> dict :
 
     def is_empty(value):
         return value in ["", None, {}, [], "null"]
-    
-    # 기본 통합 데이터 템플릿
-    basic_template = {
-        "name": "", # 회사명
-        "established_year": "", # 설립 연도
-        "company_type": "", # 회사 유형 (주식회사, 유한회사 등)
-        "is_listed": False, # 상장 여부
-        "homepage": "", # 회사 홈페이지 URL
-        "description": "", # 회사 설명
-        "address": "", # 회사 주소
-        "industry": "", # 산업 분야 정보
-        "products_services": "", # 제품/서비스 이름 배열
-        "key_executive": "", # 주요 경영진(대표자) 이름
-        "employee_count": "", # 현재 직원 수
-        "employee_history": "", # 과거 직원 수 추이
-        "latest_revenue": "", # 최근 매출액 (원)
-        "latest_operating_income": "", # 최근 영업이익 (원)
-        "latest_net_income": "", # 최근 순이익 (원)
-        "latest_fiscal_year": "", # 최근 재무 정보의 회계연도
-        "financial_history": {}, # 과거 재무 정보 히스토리
-        "total_funding": "", # 총 투자 유치 금액 (원)
-        "latest_funding_round": "", # 최근 투자 라운드 명칭
-        "latest_funding_date": "", # 최근 투자 날짜
-        "latest_valuation": "", # 최근 기업가치 (원)
-        "investment_history": "", # 투자 히스토리
-        "investors": "", # 주요 투자자 목록
-        "market_cap": "", # 시가총액 (원)
-        "stock_ticker": "", # 주식 종목 코드
-        "stock_exchange": "", # 상장된 증권거래소
-        "patent_count": "", # 특허 수
-        "trademark_count": "", # 상표 수
-        "ip_details": "", # 지식재산 상세 정보
-        "tech_stack": "", # 기술 스택 키워드
-        "recent_news": "", # 최근 뉴스/보도자료
-        "target_customers": "", # 주요 목표 고객층
-        "competitors": "", # 주요 경쟁사
-        "strengths": "", # 강점
-        "risk_factors": "", # 위험 요인  
-        "recent_trends": "", # 최근 동향
-    }
 
     # 데이터 수집이 실패된 경우
     if not isinstance(jobkorea_data, dict) or "error" in jobkorea_data:
@@ -58,7 +19,7 @@ def merge_company_info (jobkorea_data: dict, saramin_data: dict) -> dict :
 
     # 모든 사이트가 실패한 경우
     if not jobkorea_data and not saramin_data:
-        return deepcopy(basic_template)
+        return deepcopy(basic_template) # 기본 데이터 템플릿
     
     # 최종 통합 데이터
     merged_data = {}


### PR DESCRIPTION
[ 작업 설명 ]
- common 폴더를 생성
- 기업 정보 템플릿을 common_field_template.py에 분리하여 공통 관리하도록 개선